### PR TITLE
[airgapped] use `ctx.download_and_extract` over `ctx.download`

### DIFF
--- a/go/private/sdk.bzl
+++ b/go/private/sdk.bzl
@@ -202,30 +202,11 @@ def _remote_sdk(ctx, urls, strip_prefix, sha256):
     if len(urls) == 0:
         fail("no urls specified")
     ctx.report_progress("Downloading and extracting Go toolchain")
-    if urls[0].endswith(".tar.gz"):
-        # BUG(#2771): Use a system tool to extract the archive instead of
-        # Bazel's implementation. With some configurations (macOS + Docker +
-        # some particular file system binding), Bazel's implementation rejects
-        # files with invalid unicode names. Go has at least one test case with a
-        # file like this, but we haven't been able to reproduce the failure, so
-        # instead, we use this workaround.
-        if strip_prefix != "go":
-            fail("strip_prefix not supported")
-        ctx.download(
-            url = urls,
-            sha256 = sha256,
-            output = "go_sdk.tar.gz",
-        )
-        res = ctx.execute(["tar", "-xf", "go_sdk.tar.gz", "--strip-components=1"])
-        if res.return_code:
-            fail("error extracting Go SDK:\n" + res.stdout + res.stderr)
-        ctx.delete("go_sdk.tar.gz")
-    else:
-        ctx.download_and_extract(
-            url = urls,
-            stripPrefix = strip_prefix,
-            sha256 = sha256,
-        )
+    ctx.download_and_extract(
+        url = urls,
+        stripPrefix = strip_prefix,
+        sha256 = sha256,
+    )
 
 def _local_sdk(ctx, path):
     for entry in ["src", "pkg", "bin", "lib"]:


### PR DESCRIPTION
As we learned when attempting to use `rules_rust` in an airgapped environment (see
https://github.com/lowRISC/rules_rust/commit/3ea1eda511b120054d512f174de55999997b567a), the `ctx.download` action does not seem to cache downloads in the repository cache. As such, files will not be available on airgapped system simply by prefetching/populating the repository cache. This patches `rules_go` to only download go toolchains with the `ctx.download_and_extract` action until Issue #2771 (https://github.com/bazelbuild/rules_go/issues/2771) is properly resolved.

Signed-off-by: Timothy Trippel <ttrippel@google.com>